### PR TITLE
feat: Limit node creation to once per node and enable continuous chil…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
+
+0.0.22 (Unreleased)
+Refactored tap detection logic to ensure that the root node can trigger the creation of child nodes even after being moved.
+Implemented canvas-level tap detection for nodes, removing reliance on static GestureDetector within nodes.
+Fixed issue where child nodes would overlap by dynamically placing them at random but controlled distances from the root node.
+Added null safety checks when determining if a root node was tapped, preventing errors when no node is tapped.
+
 0.0.21
 Added functionality to create two child nodes when the root node is tapped.
 Child nodes are placed further away from the root node to avoid overlap.
 Nodes are connected to the root node with edges.
 Added a reset button to clear the canvas and leave only the root node.
 Updated text color inside ProfileTile to black for better readability.
+
 
 ## 0.0.10
 

--- a/example/lib/level_of_detail.dart
+++ b/example/lib/level_of_detail.dart
@@ -72,7 +72,7 @@ class _LevelOfDetailState extends State<LevelOfDetail> {
             );
           },
         ),
-      ),
+      ), metadata: {},
     ));
   }
 

--- a/example/lib/web_views.dart
+++ b/example/lib/web_views.dart
@@ -33,7 +33,7 @@ class _WebViewsState extends State<WebViews> {
           Builder(builder: (context) {
             final colors = Theme.of(context).colorScheme;
             return Container(
-              color: colors.surfaceVariant,
+              color: colors.surfaceContainerHighest,
               child: Row(
                 children: [
                   const Spacer(),
@@ -54,7 +54,7 @@ class _WebViewsState extends State<WebViews> {
             ),
           ),
         ],
-      ),
+      ), metadata: {},
     );
   }
 

--- a/example/lib/widgets.dart
+++ b/example/lib/widgets.dart
@@ -20,14 +20,14 @@ class _WidgetsState extends State<Widgets> {
         size: const Size(500, 800),
         offset: Offset.zero,
         child: const CounterExample(),
-        label: 'Counter Example',
+        label: 'Counter Example', metadata: {},
       ),
       InfiniteCanvasNode(
         key: UniqueKey(),
         size: const Size(500, 800),
         offset: const Offset(550, 200),
         child: const DraggableExample(),
-        label: 'Draggable Example',
+        label: 'Draggable Example', metadata: {},
       ),
     ]);
   }

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -2,33 +2,34 @@ PODS:
   - audio_session (0.0.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
-  - FMDB (2.7.5):
-    - FMDB/standard (= 2.7.5)
-  - FMDB/standard (2.7.5)
   - just_audio (0.0.1):
     - FlutterMacOS
-  - path_provider_macos (0.0.1):
+  - package_info_plus (0.0.1):
     - FlutterMacOS
-  - sqflite (0.0.2):
+  - path_provider_foundation (0.0.1):
+    - Flutter
     - FlutterMacOS
-    - FMDB (>= 2.7.5)
+  - sqflite (0.0.3):
+    - Flutter
+    - FlutterMacOS
   - url_launcher_macos (0.0.1):
     - FlutterMacOS
-  - wakelock_macos (0.0.1):
+  - video_player_avfoundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - wakelock_plus (0.0.1):
     - FlutterMacOS
 
 DEPENDENCIES:
   - audio_session (from `Flutter/ephemeral/.symlinks/plugins/audio_session/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - just_audio (from `Flutter/ephemeral/.symlinks/plugins/just_audio/macos`)
-  - path_provider_macos (from `Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos`)
-  - sqflite (from `Flutter/ephemeral/.symlinks/plugins/sqflite/macos`)
+  - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
+  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
+  - sqflite (from `Flutter/ephemeral/.symlinks/plugins/sqflite/darwin`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
-  - wakelock_macos (from `Flutter/ephemeral/.symlinks/plugins/wakelock_macos/macos`)
-
-SPEC REPOS:
-  trunk:
-    - FMDB
+  - video_player_avfoundation (from `Flutter/ephemeral/.symlinks/plugins/video_player_avfoundation/darwin`)
+  - wakelock_plus (from `Flutter/ephemeral/.symlinks/plugins/wakelock_plus/macos`)
 
 EXTERNAL SOURCES:
   audio_session:
@@ -37,24 +38,29 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral
   just_audio:
     :path: Flutter/ephemeral/.symlinks/plugins/just_audio/macos
-  path_provider_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos
+  package_info_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
+  path_provider_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
   sqflite:
-    :path: Flutter/ephemeral/.symlinks/plugins/sqflite/macos
+    :path: Flutter/ephemeral/.symlinks/plugins/sqflite/darwin
   url_launcher_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
-  wakelock_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/wakelock_macos/macos
+  video_player_avfoundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/video_player_avfoundation/darwin
+  wakelock_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/wakelock_plus/macos
 
 SPEC CHECKSUMS:
   audio_session: dea1f41890dbf1718f04a56f1d6150fd50039b72
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
-  FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   just_audio: 9b67ca7b97c61cfc9784ea23cd8cc55eb226d489
-  path_provider_macos: 05fb0ef0cedf3e5bd179b9e41a638682b37133ea
-  sqflite: a5789cceda41d54d23f31d6de539d65bb14100ea
-  url_launcher_macos: 597e05b8e514239626bcf4a850fcf9ef5c856ec3
-  wakelock_macos: bc3f2a9bd8d2e6c89fee1e1822e7ddac3bd004a9
+  package_info_plus: fa739dd842b393193c5ca93c26798dff6e3d0e0c
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec
+  url_launcher_macos: 5f437abeda8c85500ceb03f5c1938a8c5a705399
+  video_player_avfoundation: 7c6c11d8470e1675df7397027218274b6d2360b3
+  wakelock_plus: 4783562c9a43d209c458cb9b30692134af456269
 
 PODFILE CHECKSUM: 236401fc2c932af29a9fcf0e97baeeb2d750d367
 

--- a/example/macos/Runner/AppDelegate.swift
+++ b/example/macos/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import Cocoa
 import FlutterMacOS
 
-@NSApplicationMain
+@main
 class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return true

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -395,18 +395,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -443,18 +443,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   nested:
     dependency: transitive
     description:
@@ -736,10 +736,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -872,10 +872,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
   wakelock_plus:
     dependency: transitive
     description:

--- a/lib/src/domain/model/node.dart
+++ b/lib/src/domain/model/node.dart
@@ -12,7 +12,7 @@ class InfiniteCanvasNode<T> {
     this.resizeMode = ResizeMode.disabled,
     this.allowMove = true,
     this.clipBehavior = Clip.none,
-    this.value,
+    this.value, required Map<String, bool> metadata,
   });
 
   String get id => key.toString();

--- a/lib/src/presentation/widgets/drag_handle.dart
+++ b/lib/src/presentation/widgets/drag_handle.dart
@@ -145,7 +145,7 @@ class _DragHandleState extends State<DragHandle> {
           height: size,
           width: size,
           decoration: BoxDecoration(
-            color: colors.surfaceVariant,
+            color: colors.surfaceContainerHighest,
             border: Border.all(
               color: colors.onSurfaceVariant,
               width: 1,

--- a/lib/src/presentation/widgets/grid_background.dart
+++ b/lib/src/presentation/widgets/grid_background.dart
@@ -22,7 +22,7 @@ class GridBackgroundBuilder extends StatelessWidget {
 
     final colors = Theme.of(context).colorScheme;
     return Material(
-      color: colors.background,
+      color: colors.surface,
       child: Stack(
         clipBehavior: Clip.none,
         children: <Widget>[
@@ -36,7 +36,7 @@ class GridBackgroundBuilder extends StatelessWidget {
                   width: cellWidth,
                   decoration: BoxDecoration(
                     border: Border.all(
-                      color: colors.onBackground.withOpacity(0.1),
+                      color: colors.onSurface.withOpacity(0.1),
                       width: 1,
                     ),
                   ),


### PR DESCRIPTION
0.0.22 released
Refactored tap detection logic to ensure that the root node can trigger the creation of child nodes even after being moved.
Implemented canvas-level tap detection for nodes, removing reliance on static GestureDetector within nodes.
Fixed issue where child nodes would overlap by dynamically placing them at random but controlled distances from the root node.
Added null safety checks when determining if a root node was tapped, preventing errors when no node is tapped.